### PR TITLE
Remove Algolia keys for accelerator

### DIFF
--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -34,11 +34,11 @@
     style="display:none;visibility:hidden"></iframe></noscript>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
   <script type="text/javascript"> docsearch({
-    apiKey: '0f7d085bf26451c55de17bc56edc124b',
-    indexName: 'wso2_ob',
+    apiKey: '',
+    indexName: '',
     inputSelector: '.md-search__input',
     debug: false, // Set debug to true if you want to inspect the dropdown
-    algoliaOptions: {"facetFilters":["language:en","version:3.0.0"]}
+    algoliaOptions: {"facetFilters":["language:en","version:latest"]}
     });
   </script>
 {% endblock %}

--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -38,7 +38,7 @@
     indexName: '',
     inputSelector: '.md-search__input',
     debug: false, // Set debug to true if you want to inspect the dropdown
-    algoliaOptions: {"facetFilters":["language:en","version:latest"]}
+    algoliaOptions: {"facetFilters":["language:en","version:1.0.0"]}
     });
   </script>
 {% endblock %}
@@ -46,7 +46,7 @@
 {% block site_meta %}
   <meta charset="utf-8"/>
   <meta name="docsearch:language" content="en" />
-  <meta name="docsearch:version" content="3.0.0" />
+  <meta name="docsearch:version" content="1.0.0" />
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
This PR will remove the API keys and Algolia configs that are related to th OB3.0 Accelerator doc space. This is to request UK Toolkit doc space-specific API keys to run the site search tool.