### PR TITLE
Add algolia keys

### DIFF
--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -33,14 +33,14 @@
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSWTP6" height="0" width="0"
     style="display:none;visibility:hidden"></iframe></noscript>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<!--   <script type="text/javascript"> docsearch({
-   apiKey: '',
-    indexName: '',
+  <script type="text/javascript"> docsearch({
+   apiKey: '5f6354dee162852418c289fabd46faf5',
+    indexName: 'wso2_toolkit',
     inputSelector: '.md-search__input',
     debug: false, // Set debug to true if you want to inspect the dropdown
     algoliaOptions: {"facetFilters":["language:en","version:1.0.0"]}
     });
-  </script> -->
+  </script>
 {% endblock %}
 
 {% block site_meta %}


### PR DESCRIPTION
This PR is to add algolia keys for the doc space. Algolia is a search tool that we use for content filter/search within the doc space. 