### PR TITLE
Add consent reauthentication and multi-auth 

### DIFF
--- a/en/docs/try-out/account-and-transaction-flow.md
+++ b/en/docs/try-out/account-and-transaction-flow.md
@@ -297,7 +297,31 @@ user that has a `subscriber` role.
     ```
 
    The authorization code from the below URL is in the code parameter (code=`5591c5a0-14d0-3ca9-bec2-c1efe86e32ce`).
-   
+
+#### Consent Re-authentication for Account Consents
+
+ Account consents are long-lived consents and PSUs can re-authenticate account consents. Consent re-authentication is 
+ the process that enables an ASPSP to authenticate a PSU more than once for the same consent. To re-authenticate a consent:
+ 
+ - The consent must be in the authorized state.
+ - The `ExpirationDateTime` of the consent should not have elapsed.
+ 
+ Once re-authentication is successful, an AISP must not use or refresh access tokens that were issued for the same consent. 
+ The ASPSP can decide to invalidate the previously issued tokens for the same consent. 
+ 
+??? tip "Changing authorized accounts during re-authentication"
+
+     In the Account and transaction flow, the PSU can change the account IDs related to a consent during consent re-authentication. 
+     The ASPSP can allow the PSU to change the account IDs using the following configurations:
+     
+     1. Open the `<IS_HOME>/repository/conf/deployment.toml` file.
+     2. Set the following configuration to `true`:
+        ``` toml
+        [open_banking_uk.consent]
+        acc_update_by_psu_enabled = false
+        ```
+    3. Restart the Identity Server.
+     
 ### Generating user access token   
 
 In this section, you will be generating an access token using the authorization code generated in the section [above](authorizing-a-consent).

--- a/en/docs/try-out/payment-initiation-flow.md
+++ b/en/docs/try-out/payment-initiation-flow.md
@@ -232,7 +232,7 @@ account. When a PSU initiates a payment through a PISP, the ASPSP checks if the 
 a single user or multiple users. Only the first user/PSU will be able to authorize or stage the payment-order consent 
 through the open banking solution and other PSUs have to authorize through the bank’s online portal.
 
-For an ASPSP to check the authorisation type, the payment initiation request should define the MultiAuthorisation object, 
+For an ASPSP to check the authorisation type, the payment initiation request should define the Authorisation object, 
 which is optional as per the [Open Data API specification of OBIE](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/999426309/Payment+Initiation+API+Specification+-+v3.1.1#PaymentInitiationAPISpecification-v3.1.1-MultipleAuthorisation).
    
 ### Generating user access token   

--- a/en/docs/try-out/payment-initiation-flow.md
+++ b/en/docs/try-out/payment-initiation-flow.md
@@ -223,6 +223,17 @@ user that has a `subscriber` role.
     ```
 
    The authorization code from the below URL is in the code parameter (code=`5591c5a0-14d0-3ca9-bec2-c1efe86e32ce`).
+
+#### Multi-Authorisation for payment consents
+
+The Multiple Authorisation Management API in WSO2 Open Banking allows ASPSPs to facilitate a payment initiation request 
+that requires the authorisation of multiple bank customers, for example, a payment initiation request from a joint-bank 
+account. When a PSU initiates a payment through a PISP, the ASPSP checks if the payment consent has to be authorized by 
+a single user or multiple users. Only the first user/PSU will be able to authorize or stage the payment-order consent 
+through the open banking solution and other PSUs have to authorize through the bank’s online portal.
+
+For an ASPSP to check the authorisation type, the payment initiation request should define the MultiAuthorisation object, 
+which is optional as per the [Open Data API specification of OBIE](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/999426309/Payment+Initiation+API+Specification+-+v3.1.1#PaymentInitiationAPISpecification-v3.1.1-MultipleAuthorisation).
    
 ### Generating user access token   
 


### PR DESCRIPTION
This PR is to add consent reauthentication and multi-auth for accounts and payments docs respectively. 

References: 
1. [Consent Reauth](https://docs.google.com/document/d/1WXLTqF1X1OUEX03DLx_aKRdBZAmtaSpaYTPAduU6a4c/edit)
2. [Multi Auth](https://docs.google.com/document/d/1TyudN6XHbk3wllJaloSU0xABqx_1BJHunS4bykHOFEU/edit#heading=h.l416fvxi2c06)