### PR TITLE
Add conf for issue redirection

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report an issue
+    url: https://github.com/wso2/docs-open-banking/issues/new?labels=uk-toolkit
+    about: Click 'Open' to continue. You will be creating the new issue in the 'wso2/docs-open-banking' repo.


### PR DESCRIPTION
This PR is to config this repo in a way that, when a we click on the Create New Issue option, it will redirect us to the New Issue Creation page of **WSO2 OB3.0 Repo New Issue Page.**