### PR TITLE
Fix configuration key for maximum future payment days

### DIFF
--- a/en/docs/conformance/functional-conformance-suite.md
+++ b/en/docs/conformance/functional-conformance-suite.md
@@ -222,7 +222,7 @@ For testing purposes, you can host the well-known configuration file via [Github
 
     ```toml
     [open_banking_uk.consent.payment_restrictions]
-    max_instructed_amount = "365"
+    max_future_days = "365"
     ```
 
 4. Locate the `[open_banking_uk.consent]` tag.


### PR DESCRIPTION
## Purpose
- Fixes https://github.com/wso2/docs-open-banking/issues/1033

- Fix configuration mismatch in UK toolkit docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration parameter documentation to clarify the correct semantic meaning of a constraint field, changing from instructed amount to future days limit in the Open Banking UK conformance guidelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->